### PR TITLE
chore: User REDIS URL instead of HOST and PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ An example of this project environment variables:
 ```
 GHAPP_API_HOST=https://127.0.0.1/github
 GHAPP_SERVER_PORT=8083
-GHAPP_REDIS_HOST=redis://redis
-GHAPP_REDIS_PORT=6380
+GHAPP_REDIS_URL=redis://username:password@host:port
 WIRE_SDK_API_HOST=https://nginz-https.chala.wire.link
 WIRE_SDK_API_TOKEN=myApiToken
 WIRE_SDK_APP_ID=f562e146-dec2-4d85-93c7-7132746b5cca

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,8 +111,7 @@ tasks {
     test {
         environment("GHAPP_API_HOST", "http://0.0.0.0")
         environment("GHAPP_SERVER_PORT", "8083")
-        environment("GHAPP_REDIS_HOST", "redis://localhost")
-        environment("GHAPP_REDIS_PORT", "6379")
+        environment("GHAPP_REDIS_URL", "redis://localhost:6379")
         environment("WIRE_SDK_API_HOST", "https://nginz-https.chala.wire.link")
         environment("WIRE_SDK_API_TOKEN", "myApiToken")
         environment("WIRE_SDK_APP_ID", "f562e146-dec2-4d85-93c7-7132746b5cca")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,7 @@ services:
     environment:
       - GHAPP_API_HOST=${GHAPP_API_HOST}
       - GHAPP_SERVER_PORT=${GHAPP_SERVER_PORT}
-      - GHAPP_REDIS_HOST=${GHAPP_REDIS_HOST}
-      - GHAPP_REDIS_PORT=${GHAPP_REDIS_PORT}
+      - GHAPP_REDIS_URL=${GHAPP_REDIS_URL}
       - WIRE_SDK_API_HOST=${WIRE_SDK_API_HOST}
       - WIRE_SDK_API_TOKEN=${WIRE_SDK_API_TOKEN}
       - WIRE_SDK_APP_ID=${WIRE_SDK_APP_ID}
@@ -28,14 +27,12 @@ services:
   redis:
     image: redis:7
     container_name: github_redis
-    environment:
-      - GHAPP_REDIS_PORT=${GHAPP_REDIS_PORT}
     restart: unless-stopped
     ports:
-      - "${GHAPP_REDIS_PORT}:${GHAPP_REDIS_PORT}"
+      - "6379:6379"
     volumes:
       - redis-data:/data
-    command: sh -c "redis-server --port $GHAPP_REDIS_PORT --save 60 1 --loglevel warning --appendonly yes"
+    command: sh -c "redis-server --save 60 1 --loglevel warning --appendonly yes"
 
 volumes:
   redis-data:

--- a/helm/githubapp/templates/statefulset.yaml
+++ b/helm/githubapp/templates/statefulset.yaml
@@ -68,16 +68,11 @@ spec:
                   key: WIRE_SDK_CRYPTOGRAPHY_STORAGE_PASSWORD
             {{- end }}
             {{- if .Values.redis }}
-            - name: GHAPP_REDIS_HOST
+            - name: GHAPP_REDIS_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.redis.secretName }}
-                  key: {{ .Values.redis.hostKey }}
-            - name: GHAPP_REDIS_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.redis.secretName }}
-                  key: {{ .Values.redis.portKey }}
+                  key: {{ .Values.redis.urlKey }}
             {{- end }}
           volumeMounts:
             - name: data

--- a/helm/githubapp/values.yaml
+++ b/helm/githubapp/values.yaml
@@ -31,8 +31,7 @@ secrets:
 
 redis:
   secretName: "githubapp-valkey-secrets"
-  hostKey: "host"
-  portKey: "port"
+  urlKey: "url"
 
 # Persistent storage configuration
 persistence:

--- a/src/main/kotlin/com/wire/github/config/Modules.kt
+++ b/src/main/kotlin/com/wire/github/config/Modules.kt
@@ -5,8 +5,7 @@ import com.wire.github.util.ENV_VAR_API_HOST
 import com.wire.github.util.ENV_VAR_API_TOKEN
 import com.wire.github.util.ENV_VAR_APPLICATION_ID
 import com.wire.github.util.ENV_VAR_CRYPTOGRAPHY_STORAGE_KEY
-import com.wire.github.util.ENV_VAR_REDIS_HOST
-import com.wire.github.util.ENV_VAR_REDIS_PORT
+import com.wire.github.util.ENV_VAR_REDIS_URL
 import com.wire.github.util.SignatureValidator
 import com.wire.github.util.TemplateHandler
 import com.wire.sdk.WireAppSdk
@@ -23,7 +22,7 @@ val projectModules = module {
     }
     single { SignatureValidator() }
     single { TemplateHandler() }
-    single { RedisClient.create("$ENV_VAR_REDIS_HOST:$ENV_VAR_REDIS_PORT") }
+    single { RedisClient.create(ENV_VAR_REDIS_URL) }
     single<StatefulRedisConnection<String, String>> { get<RedisClient>().connect() }
 }
 

--- a/src/main/kotlin/com/wire/github/util/EnvironmentVariables.kt
+++ b/src/main/kotlin/com/wire/github/util/EnvironmentVariables.kt
@@ -33,28 +33,15 @@ val ENV_VAR_HOST: String = System
     )
 
 /**
- * Redis Host URL
- * In case it needs a password, must be included in this same environment variable.
- * Examples:
- * - "redis://host"
- * - "redis://[:password@]host"
+ * Redis Connection URL
+ * Should contain all the necessary information
+ * Example: rediss://username:password@host:port
  */
-val ENV_VAR_REDIS_HOST: String = System
+val ENV_VAR_REDIS_URL: String = System
     .getenv()
     .getOrDefault(
-        "GHAPP_REDIS_HOST",
-        "redis://localhost"
-    )
-
-/**
- * Redis Port Number
- * To used when connecting and also exposed via docker-compose.
- */
-val ENV_VAR_REDIS_PORT: String = System
-    .getenv()
-    .getOrDefault(
-        "GHAPP_REDIS_PORT",
-        "6379"
+        "GHAPP_REDIS_URL",
+        "redis://localhost:6379"
     )
 
 /**


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Instead of trying to build the full connection url for redis, we can receive the full connection url directly.

### Solutions

Use redis full connection url directly