### PR TITLE
chore: Add prefix for Redis keys

### DIFF
--- a/src/main/kotlin/com/wire/github/util/Extensions.kt
+++ b/src/main/kotlin/com/wire/github/util/Extensions.kt
@@ -2,6 +2,8 @@ package com.wire.github.util
 
 import com.wire.sdk.model.QualifiedId
 
-fun QualifiedId.toStorageKey() = "${this.id}@${this.domain}"
+private const val STORAGE_KEY_PREFIX = "github-app:"
 
-fun String.toStorageKey(domain: String) = "$this@$domain"
+fun QualifiedId.toStorageKey() = "$STORAGE_KEY_PREFIX${this.id}@${this.domain}"
+
+fun String.toStorageKey(domain: String) = "$STORAGE_KEY_PREFIX$this@$domain"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Redis/Valkey in staging cluster can only access keys from specific namespace

### Solutions

Add a prefix with namespace naming